### PR TITLE
Fix for _inject() not getting called in browser globals environment running Turbolinks

### DIFF
--- a/src/umbed.js
+++ b/src/umbed.js
@@ -205,9 +205,7 @@
       // Browser globals
       } else {
         _includeDependencies().then(function () {
-          root.addEventListener("load", function(e) {
-            _inject(options);
-          });
+          _inject(options);
         });
       }
 


### PR DESCRIPTION
Fix for _inject() not getting called in browser globals environment running Turbolinks by no-longer waiting for promises _and_ document load. Issue #17